### PR TITLE
Rework of QuPath extension handling

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,10 +14,10 @@ RUN apt-get update -y && \
          qt5dxcb-plugin && \
      rm -rf /var/lib/apt/lists/*
 
-RUN mkdir -p /opt/qupath &&\
-    chmod 777 /opt/qupath &&\
+RUN mkdir -p /opt/qupath && \
+    chmod 777 /opt/qupath && \
     cd /opt/qupath/ && \
-    wget https://github.com/qupath/qupath/releases/download/v0.6.0/QuPath-v0.6.0-Linux.tar.xz &&\
+    wget https://github.com/qupath/qupath/releases/download/v0.6.0/QuPath-v0.6.0-Linux.tar.xz && \
     tar -xvf QuPath-v0.6.0-Linux.tar.xz && \
     rm /opt/qupath/QuPath-v0.6.0-Linux.tar.xz -rf && \
     chmod u+x /opt/qupath/QuPath/bin/QuPath
@@ -29,20 +29,17 @@ RUN APP_ICON_URL=https://github.com/qupath/qupath/wiki/images/qupath_128.png && 
 COPY startapp.sh /startapp.sh
 RUN chmod +x /startapp.sh
 
-# Installing a few extensions
-RUN cd /opt/qupath/QuPath/lib/app/ && \
-    wget https://github.com/qupath/qupath-extension-djl/releases/download/v0.4.0/qupath-extension-djl-0.4.0.jar &&\
-    wget https://github.com/qupath/qupath-extension-stardist/releases/download/v0.6.0/qupath-extension-stardist-0.6.0.jar &&\
-    wget https://github.com/qupath/qupath-extension-omero/releases/download/v0.1.0/qupath-extension-omero-0.1.0.jar &&\
+# Creating the extensions directory and Installing extensions
+RUN mkdir -p /opt/qupath/user_dir/extensions && \
+    cd /opt/qupath/user_dir/extensions && \
+    wget https://github.com/qupath/qupath-extension-djl/releases/download/v0.4.0/qupath-extension-djl-0.4.0.jar && \
+    wget https://github.com/qupath/qupath-extension-stardist/releases/download/v0.6.0/qupath-extension-stardist-0.6.0.jar && \
+    wget https://github.com/qupath/qupath-extension-omero/releases/download/v0.1.0/qupath-extension-omero-0.1.0.jar && \
     wget https://github.com/qupath/qupath-extension-omero/releases/download/v0.1.0/qupath-extension-omero-0.1.0-javadoc.jar && \
-    sed -i '/^\[Application\]$/a app.classpath=$APPDIR/qupath-extension-djl-0.4.0.jar' QuPath.cfg  && \
-    sed -i '/^\[Application\]$/a app.classpath=$APPDIR/qupath-extension-stardist-0.6.0.jar' QuPath.cfg &&\
-    sed -i '/^\[Application\]$/a app.classpath=$APPDIR/qupath-extension-omero-0.1.0.jar' QuPath.cfg && \
-    sed -i '/^\[Application\]$/a app.classpath=$APPDIR/qupath-extension-omero-0.1.0-javadoc.jar' QuPath.cfg && \
-# get the OMERO ICE Java dependency
     wget https://github.com/ome/openmicroscopy/releases/download/v5.6.15/OMERO.java-5.6.15-ice36.zip && \
     unzip OMERO.java-5.6.15-ice36.zip && \
-    rm OMERO.java-5.6.15-ice36.zip 
+    rm OMERO.java-5.6.15-ice36.zip && \
+    chmod -R 755 /opt/qupath/user_dir/
 
 # Set the name of the application.
 ENV APP_NAME="QuPath"

--- a/startapp.sh
+++ b/startapp.sh
@@ -1,6 +1,12 @@
-#!/bin/sh -f
+#!/bin/sh
+
+# set this first, so it is inherited by the setting of the preferences and the actual QuPath run
+export _JAVA_OPTIONS="-Duser.home=/tmp -Djavafx.cachedir=/tmp"
+
+# set the home directory of the QuPath preferences before starting, so extensions can be loaded
+echo "qupath.lib.gui.prefs.PathPrefs.userPathProperty().set('/opt/qupath/user_dir')" > /opt/qupath/set_preference_script.groovy
+/opt/qupath/QuPath/bin/QuPath script /opt/qupath/set_preference_script.groovy --save
 
 # The path `/opt/qupath/infile.tiff` is important as the Galaxy IT is inserting the user-chosen file into this path.
-
 cd $HOME/outputs
-_JAVA_OPTIONS="-Duser.home=/tmp -Djavafx.cachedir=/tmp" exec /opt/qupath/QuPath/bin/QuPath --image /opt/qupath/infile.tiff --quiet
+exec /opt/qupath/QuPath/bin/QuPath --image /opt/qupath/infile.tiff --quiet


### PR DESCRIPTION
As the OMERO extension needs the (optional) dependencies from `OMERO.java-5.6.15-ice36`  for the enhanced Pixel API, the current approach of adding the .jar files to the `QuPath.cfg` seemed too hacky and made things a bit more complicated for the OMERO dependency, as it had a lot of .jar files in its subfolder.

Instead, I drew inspiration from [this](https://forum.image.sc/t/qupath-extension-folder-on-distant-server/78190) image.sc post and created a groovy script that runs before the actual QuPath for the end user starts, and sets the user directory preference.

Then all the Extensions can be installed in that user directory no matter if done by dockerfile or later on manually by the user with the new extension manager of QuPath.

Overall, this seems more in line how Extensions would be handled "naturally" by QuPath.

Unfortunately, this took me waaayyyy too long, as I had no prior hands-on experience with Docker.